### PR TITLE
fix/fetch-tarball-auth

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,7 @@ export const downloadToFile = async (
 		cachedir(),
 		cacheFileName(owner, name, hash, Date.now()),
 	);
-	const tarball = await fetchTarball(owner, name, branch);
+	const tarball = await fetchTarball(owner, name, { ref: branch, auth_token });
 	await toFile(location, tarball);
 	return location;
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -23,10 +23,18 @@ export type Tarball = {
 export const fetchTarball = async (
 	owner: string,
 	repo: string,
-	ref?: string,
+	{ ref, auth_token }: { ref?: string; auth_token?: string } = {},
 ): Promise<Tarball> => {
 	ref = ref ?? "HEAD";
-	const res = await fetch(`https://github.com/${owner}/${repo}/tarball/${ref}`);
+	const auth = auth_token ?? process.env["BEGIT_GH_API_KEY"];
+	const res = await fetch(
+		`https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`,
+		auth
+			? {
+					headers: { Authorization: `Bearer ${auth}` },
+				}
+			: undefined,
+	);
 	return {
 		body: res.body as ReadableStream<Uint8Array>,
 		name: res.url.split("/").pop()!,


### PR DESCRIPTION
Fixes #2 

Use github api in `fetchTarball` to be able to use auth token

https://docs.github.com/fr/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-tar